### PR TITLE
Added application.h to fix compile error

### DIFF
--- a/firmware/elapsedMillis.h
+++ b/firmware/elapsedMillis.h
@@ -23,6 +23,8 @@
  * THE SOFTWARE.
  */
 
+#include "application.h"
+
 #ifndef elapsedMillis_h
 #define elapsedMillis_h
 


### PR DESCRIPTION
Hiya Paul! Caught this error while scraping through the libraries for Electron compatibility. Looks like it needs `application.h` so that `millis()` works. Could ya accept this change and reimport the library? It's in the top 50!

R
